### PR TITLE
Fix - In the X64 & GCC 7.X.X build environment, the -foptimize-strlen…

### DIFF
--- a/makefile
+++ b/makefile
@@ -575,8 +575,7 @@ BUILDOUT = $(BUILDOBJ)
 include makefile.libretro
 
 # combine the various definitions to one
-# In the X64 GCC 7.4.0 build environment, some M92 games freeze when they start, and temporary solutions are used here.
-CCOMFLAGS += $(INCFLAGS) -fno-delete-null-pointer-checks -fno-optimize-strlen
+CCOMFLAGS += $(INCFLAGS) -fno-delete-null-pointer-checks
 CDEFS = $(DEFS)
 
 #-------------------------------------------------

--- a/makefile.libretro
+++ b/makefile.libretro
@@ -438,6 +438,12 @@ UTILOBJS = \
 
 $(OBJ)/libutil.a: $(UTILOBJS)
 
+ifeq ($(PTR64), 1)
+ifeq ($(shell echo `$(CC) -dumpversion` ">= 7" | bc -l), 1)
+$(LIBOBJ)/util/options.o: CFLAGS += -fno-optimize-strlen
+endif
+endif
+
 #-------------------------------------------------
 # expat library objects
 #-------------------------------------------------


### PR DESCRIPTION
… parameter (included in -O2) causes lib/util/options.c to produce incorrect results, causing some M92 games to freeze at startup. (everything works fine with GCC 4.9.2 and CLANG)